### PR TITLE
[CI validation] Check 0.9.4 compatibility and Check matrix workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,75 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  format:
+    uses: ./.github/workflows/format.yml
+
+  build:
+    needs: format
+    runs-on: ubuntu-latest
+    name: Check ${{ matrix.check }}
+
+    # The other workflows test with the Check that the platform packages
+    # provide, which is a recent release. README.md promises Check 0.9.4 or
+    # newer, so this workflow builds the declared minimum, the releases of
+    # RHEL 7 (0.9.9) and RHEL 8 (0.12.0) and the 0.10.0 of Ubuntu 18.04 to
+    # 20.04 and Debian 9 and 10 from source and runs the tests against them.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: 0.9.4
+            url: https://downloads.sourceforge.net/project/check/check/0.9.4/check-0.9.4.tar.gz
+            sha256: 2c1063b06edfd78a97803b36b0cc7bd4e01dd923655540a31a2185b7215f8cbc
+          - check: 0.9.9
+            url: https://downloads.sourceforge.net/project/check/check/0.9.9/check-0.9.9.tar.gz
+            sha256: 1a7a9abb9d051e1b9da4149ce651436a29e20135a40bdb202bd7b2bef3878ac9
+          - check: 0.10.0
+            url: https://github.com/libcheck/check/releases/download/0.10.0/check-0.10.0.tar.gz
+            sha256: f5f50766aa6f8fe5a2df752666ca01a950add45079aa06416b83765b1cf71052
+          - check: 0.12.0
+            url: https://github.com/libcheck/check/releases/download/0.12.0/check-0.12.0.tar.gz
+            sha256: 464201098bee00e90f5c4bdfa94a5d3ead8d641f9025b560a27755a83b824234
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y cmake pkg-config gcc libssl-dev libjansson-dev
+        echo "CHECK_PREFIX=$HOME/check-${{ matrix.check }}" >> "$GITHUB_ENV"
+    - name: Cache Check ${{ matrix.check }}
+      id: cache-check
+      uses: actions/cache@v6
+      with:
+        path: ~/check-${{ matrix.check }}
+        key: check-${{ matrix.check }}-${{ runner.os }}-${{ runner.arch }}
+    - name: Build Check ${{ matrix.check }}
+      if: steps.cache-check.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}
+      run: |
+        curl -fsSL -o "check-${{ matrix.check }}.tar.gz" "${{ matrix.url }}"
+        echo "${{ matrix.sha256 }}  check-${{ matrix.check }}.tar.gz" | sha256sum -c -
+        tar xzf "check-${{ matrix.check }}.tar.gz"
+        cd "check-${{ matrix.check }}"
+        # -fcommon: the 0.9.x test programs define globals in a header; no subunit: keep it self-contained
+        CFLAGS="-g -O2 -fcommon" ./configure --prefix="$CHECK_PREFIX" --disable-static --disable-subunit
+        make -j"$(nproc)"
+        make install
+    - name: Configure
+      run: >
+        PKG_CONFIG_PATH="$CHECK_PREFIX/lib/pkgconfig"
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Check=ON
+    - name: Build
+      run: cmake --build build --parallel
+    - name: Check which Check the tests load
+      run: |
+        PKG_CONFIG_PATH="$CHECK_PREFIX/lib/pkgconfig" pkg-config --modversion check
+        ldd build/check_cjose | grep -F "$CHECK_PREFIX/lib/libcheck"
+    - name: Test
+      run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ if(CJOSE_BUILD_TESTS)
     if(NOT _cjose_check_target)
         find_package(PkgConfig QUIET)
         if(PkgConfig_FOUND)
-            pkg_check_modules(CHECK QUIET check>=0.12.0 IMPORTED_TARGET)
+            pkg_check_modules(CHECK QUIET check>=0.9.4 IMPORTED_TARGET)
             if(TARGET PkgConfig::CHECK)
                 set(_cjose_check_target PkgConfig::CHECK)
             endif()
@@ -360,7 +360,7 @@ if(CJOSE_BUILD_TESTS)
     endif()
 
     if(NOT _cjose_check_target)
-        message(WARNING "Check (>= 0.12.0) not found; skipping cjose unit tests.")
+        message(WARNING "Check (>= 0.9.4) not found; skipping cjose unit tests.")
     else()
         set(CJOSE_TEST_SOURCES
             test/check_cjose.c

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementation of JOSE for C/C++
 
 * CMake (>= 3.22)
 * A C99 compiler (LLVM/Clang >= 5.1, GCC >= 4.5 or MSVC >= 14)
-* Check (>= 0.12.0) - unit testing (e.g. check-devel)
+* Check (>= 0.9.4) - unit testing (e.g. check-devel)
 * Doxygen (>= 1.8) - API documentation (optional)
 * clang-format - source formatting (optional)
 

--- a/configure
+++ b/configure
@@ -14700,19 +14700,19 @@ $as_echo "no" >&6; }
 fi
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for check >= 0.12.0" >&5
-$as_echo_n "checking for check >= 0.12.0... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for check >= 0.9.4" >&5
+$as_echo_n "checking for check >= 0.9.4... " >&6; }
 
 if test -n "$CHECK_CFLAGS"; then
     pkg_cv_CHECK_CFLAGS="$CHECK_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.12.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "check >= 0.12.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.9.4\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "check >= 0.9.4") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_CHECK_CFLAGS=`$PKG_CONFIG --cflags "check >= 0.12.0" 2>/dev/null`
+  pkg_cv_CHECK_CFLAGS=`$PKG_CONFIG --cflags "check >= 0.9.4" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14724,12 +14724,12 @@ if test -n "$CHECK_LIBS"; then
     pkg_cv_CHECK_LIBS="$CHECK_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.12.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "check >= 0.12.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.9.4\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "check >= 0.9.4") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_CHECK_LIBS=`$PKG_CONFIG --libs "check >= 0.12.0" 2>/dev/null`
+  pkg_cv_CHECK_LIBS=`$PKG_CONFIG --libs "check >= 0.9.4" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14750,9 +14750,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        CHECK_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "check >= 0.12.0" 2>&1`
+	        CHECK_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "check >= 0.9.4" 2>&1`
         else
-	        CHECK_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "check >= 0.12.0" 2>&1`
+	        CHECK_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "check >= 0.9.4" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$CHECK_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ DX_INIT_DOXYGEN([CJOSE], [Doxyfile], [doc])
 
 ### Check for CHECK
 PKG_CHECK_MODULES([CHECK],
-        [check >= 0.12.0],
+        [check >= 0.9.4],
         [have_check="yes"],
         [   AC_MSG_WARN([Check not found; cannot run unit tests!]);
             [have_check="no"]

--- a/test/check_cjose.h
+++ b/test/check_cjose.h
@@ -7,6 +7,24 @@
 
 #include <check.h>
 
+// Check 0.9.4 and 0.9.5 predate the ck_assert family, which 0.9.6 added on
+// top of fail_unless; these are 0.9.6's definitions, with the integer
+// comparison printing intmax_t like later releases do
+#ifndef ck_assert_msg
+#define ck_assert_msg fail_unless
+#endif
+#ifndef ck_assert
+#define ck_assert(C) ck_assert_msg(C, NULL)
+#endif
+#ifndef ck_assert_int_eq
+#define ck_assert_int_eq(X, Y) \
+    ck_assert_msg((X) == (Y), "Assertion '" #X "==" #Y "' failed: " #X "==%jd, " #Y "==%jd", (intmax_t)(X), (intmax_t)(Y))
+#endif
+#ifndef ck_assert_str_eq
+#define ck_assert_str_eq(X, Y) \
+    ck_assert_msg(0 == strcmp(X, Y), "Assertion '" #X "==" #Y "' failed: " #X "==\"%s\", " #Y "==\"%s\"", X, Y)
+#endif
+
 #ifdef _WIN32
 #define random rand
 #endif

--- a/test/check_concatkdf.c
+++ b/test/check_concatkdf.c
@@ -95,7 +95,7 @@ START_TEST(test_cjose_concatkdf_otherinfo_noextra)
     memset(&err, 0, sizeof(cjose_err));
     ck_assert(cjose_concatkdf_create_otherinfo(alg, 256, hdr, &otherinfo, &otherinfoLen, &err));
     actual = otherinfo;
-    ck_assert_uint_eq(otherinfoLen, 23);
+    ck_assert(otherinfoLen == 23);
     ck_assert(_cmp_lendata(&actual, alg, strlen(alg))); // ALG
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APU
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APV
@@ -123,7 +123,7 @@ START_TEST(test_cjose_concatkdf_otherinfo_apuapv)
     memset(&err, 0, sizeof(cjose_err));
     ck_assert(cjose_concatkdf_create_otherinfo(alg, 32, hdr, &otherinfo, &otherinfoLen, &err));
     actual = otherinfo;
-    ck_assert_uint_eq(otherinfoLen, 47);
+    ck_assert(otherinfoLen == 47);
     ck_assert(_cmp_lendata(&actual, alg, strlen(alg)));
     ck_assert(_cmp_lendata(&actual, apu, apuLen));
     ck_assert(_cmp_lendata(&actual, apv, apvLen));


### PR DESCRIPTION
Validation run inside the fork for a workflow change. Four commits: the ck_assert family shim for Check 0.9.4/0.9.5, the two-line #159 change (cherry-picked), the revert of the 0.12.0 minimum bump, and a `Check` workflow that builds 0.9.4, 0.9.9, 0.10.0 and 0.12.0 from source and runs the tests against them. Expected: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
